### PR TITLE
fix single file compilation and compile snek.vy

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,13 +25,15 @@ program.command('help')
     .description('print a long help message with examples')
     .action(() => { console.log('snek uses vyper to compile contracts, you need to install it with pip first') })
 
-const make = (path, output_dir, is_src=true) => {
-    vyper.compile(path, output_dir, is_src)
+const make = (path, output_dir, output_id) => {
+    vyper.compile(path, output_dir, output_id)
 }
 
 const test = (src_path, test_path, output_dir) => {
-    make(src_path, output_dir)
-    make(test_path, output_dir, false)
+    make(src_path, output_dir, 'Src')
+    make(test_path, output_dir, 'Test')
+    make('snek.vy', output_dir, 'Snek')
+    // TODO: !DMFXYZ! Need to compile snek.vy as well 
     runner.run(output_dir)
 }
 

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ const make = (path, output_dir, output_id) => {
 const test = (src_path, test_path, output_dir) => {
     make(src_path, output_dir, 'Src')
     make(test_path, output_dir, 'Test')
+    // TODO: !DMFXYZ! should the user be able to provide a custom snek.vy?
     make('snek.vy', output_dir, 'Snek')
-    // TODO: !DMFXYZ! Need to compile snek.vy as well 
     runner.run(output_dir)
 }
 

--- a/src/vyper.js
+++ b/src/vyper.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 
 module.exports = vy = {}
 
-vy._generate_json = (files, path, outputDir, id, isDir=true) => {
+vy._generate_json = (files, path, outputDir, id) => {
     const project = {
         "language": "Vyper",
         "sources": {
@@ -20,13 +20,11 @@ vy._generate_json = (files, path, outputDir, id, isDir=true) => {
     }
     const isdir = fs.lstatSync(path).isDirectory()
     for( const file of files ) {
-        console.log(`${file} !!`)
         if (!file.endsWith('.vy')) continue
         const src_path = isdir ? `${path}/${file}` : file
         const content = fs.readFileSync(src_path, {encoding: 'utf-8'})
         project['sources'][src_path] = {'content': content}
     }
-    console.log(project)
     const show =(o)=> JSON.stringify(o, null, 2)
     fs.writeFileSync(outputDir + `/${id}Input.json`, show(project))
 }


### PR DESCRIPTION
Single file compilation was not working because `path` was the file itself.
I also relaxed the idea of isSrc to just having IDs for groups of contracts generated, so that for example we can generate `snek.vy` using the same json approach.